### PR TITLE
Improve logging. Add panic handling for CLI.

### DIFF
--- a/entrypoint/entrypoint.go
+++ b/entrypoint/entrypoint.go
@@ -27,7 +27,7 @@ func checkForErrorsAndExit(err error) {
 	exitCode := defaultSuccessExitCode
 
 	if err != nil {
-		logging.GetLogger("").WithError(err).Error()
+		logging.GetLogger("").WithError(err).Error(errors.PrintErrorWithStackTrace(err))
 
 		errorWithExitCode, isErrorWithExitCode := err.(errors.ErrorWithExitCode)
 		if isErrorWithExitCode {

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -3,6 +3,7 @@ package errors
 import (
 	"fmt"
 	goerrors "github.com/go-errors/errors"
+	"github.com/urfave/cli"
 )
 
 // If this error is returned, the program should exit with the given exit code.
@@ -78,5 +79,17 @@ func Recover(onPanic func(cause error)) {
 			err = fmt.Errorf("%v", rec)
 		}
 		onPanic(WithStackTrace(err))
+	}
+}
+
+// Use this to wrap every command you add to *cli.App to handle panics by logging them with a stack trace and returning
+// an error up the chain.
+func WithPanicHandling(action func(*cli.Context) error) func(*cli.Context) error {
+	return func(context *cli.Context) (err error) {
+		defer Recover(func(cause error) {
+			err = cause
+		})
+
+		return action(context)
 	}
 }

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -12,13 +12,19 @@ var globalLogLevel = logrus.InfoLevel
 var globalLogLevelLock = sync.Mutex{}
 
 // Create a new logger with the given name
-func GetLogger(name string) *logrus.Entry {
+func GetLogger(name string) *logrus.Logger {
 	logger := logrus.New()
+
 	logger.Level = globalLogLevel
+
+	logger.Formatter = &logrus.TextFormatter{
+		FullTimestamp: true,
+	}
+
 	if name != "" {
-		return logger.WithField(loggerNameField, name)
+		return logger.WithField(loggerNameField, name).Logger
 	} else {
-		return logger.WithFields(make(logrus.Fields))
+		return logger.WithFields(make(logrus.Fields)).Logger
 	}
 }
 


### PR DESCRIPTION
This PR does the following:

1. A few tweaks to the default log settings, including enabling timestamps and showing stack traces.

1. Add a helper method to catch panics in the CLI and still show stack traces for those.