### PR TITLE
fix issue with logrus capitalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ given path is a file or a directory, reading a file as a string, and building re
 ### logging
 
 This package contains utilities for logging from our CLI apps. Instead of using Go's built-in logging library, we are 
-using [logrus](github.com/Sirupsen/logrus), as it supports log levels (INFO, WARN, DEBUG, etc), structured logging 
+using [logrus](github.com/sirupsen/logrus), as it supports log levels (INFO, WARN, DEBUG, etc), structured logging 
 (making key=value pairs easier to parse), log formatting (including text and JSON), hooks to connect logging to a 
 variety of external systems (e.g. syslog, airbrake, papertrail), and even hooks for automated testing.
  

--- a/circle.yml
+++ b/circle.yml
@@ -5,8 +5,8 @@ machine:
 dependencies:
   override:
     # Install the gruntwork-module-circleci-helpers and use it to configure the build environment and run tests.
-    - curl -Ls https://raw.githubusercontent.com/gruntwork-io/gruntwork-installer/master/bootstrap-gruntwork-installer.sh | bash /dev/stdin --version 0.0.13
-    - gruntwork-install --module-name "gruntwork-module-circleci-helpers" --repo "https://github.com/gruntwork-io/module-ci" --tag "v0.2.0"
+    - curl -Ls https://raw.githubusercontent.com/gruntwork-io/gruntwork-installer/master/bootstrap-gruntwork-installer.sh | bash /dev/stdin --version v0.0.16
+    - gruntwork-install --module-name "gruntwork-module-circleci-helpers" --repo "https://github.com/gruntwork-io/module-ci" --tag "v0.3.17"
     - configure-environment-for-gruntwork-module --terraform-version NONE --packer-version NONE --terragrunt-version NONE --go-src-path .
 
   cache_directories:

--- a/glide.lock
+++ b/glide.lock
@@ -11,7 +11,7 @@ imports:
   version: 30a891c33c7cde7b02a981314b4228ec99380cca
 - name: github.com/mattn/go-zglob
   version: 2dbd7f37a45e993d5180a251b4bdd314d6333b70
-- name: github.com/Sirupsen/logrus
+- name: github.com/sirupsen/logrus
   version: 881bee4e20a5d11a6a88a5667c6f292072ac1963
 - name: github.com/stretchr/testify
   version: 2402e8e7a02fc811447d11f881aa9746cdc57983

--- a/glide.yaml
+++ b/glide.yaml
@@ -3,7 +3,7 @@ owners:
 - name: Gruntwork
   homepage: http://www.gruntwork.io
 import:
-- package: github.com/Sirupsen/logrus
+- package: github.com/sirupsen/logrus
 - package: github.com/stretchr/testify/assert
 - package: github.com/go-errors/errors
 - package: github.com/mattn/go-zglob

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -1,7 +1,7 @@
 package logging
 
 import (
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"sync"
 )
 

--- a/shell/options.go
+++ b/shell/options.go
@@ -1,7 +1,7 @@
 package shell
 
 import (
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/gruntwork-io/gruntwork-cli/logging"
 )
 


### PR DESCRIPTION
[logrus](https://github.com/sirupsen/logrus) changed their GitHub repo to all lowercase and broke all go packages that use their library.

See [here](https://github.com/sirupsen/logrus/issues/553) and [here](https://github.com/sirupsen/logrus)