### PR TITLE
Unit tests for shell prompt functions

### DIFF
--- a/shell/prompt.go
+++ b/shell/prompt.go
@@ -1,28 +1,35 @@
 package shell
 
 import (
-	"fmt"
 	"bufio"
+	"fmt"
+	"io"
 	"os"
-	"github.com/gruntwork-io/gruntwork-cli/errors"
 	"strings"
-	"github.com/fatih/color"
+
 	"github.com/bgentry/speakeasy"
+	"github.com/fatih/color"
+
+	"github.com/gruntwork-io/gruntwork-cli/errors"
 )
 
 var BRIGHT_GREEN = color.New(color.FgHiGreen, color.Bold)
 
 // Prompt the user for text in the CLI. Returns the text entered by the user.
 func PromptUserForInput(prompt string, options *ShellOptions) (string, error) {
-	BRIGHT_GREEN.Print(prompt)
+	return FPromptUserForInput(os.Stdout, os.Stdin, prompt, options)
+}
+
+func FPromptUserForInput(out io.Writer, in io.Reader, prompt string, options *ShellOptions) (string, error) {
+	BRIGHT_GREEN.Fprint(out, prompt)
 
 	if options.NonInteractive {
-		fmt.Println()
+		fmt.Fprintln(out)
 		options.Logger.Info("The non-interactive flag is set to true, so assuming 'yes' for all prompts")
 		return "yes", nil
 	}
 
-	reader := bufio.NewReader(os.Stdin)
+	reader := bufio.NewReader(in)
 
 	text, err := reader.ReadString('\n')
 	if err != nil {
@@ -34,15 +41,21 @@ func PromptUserForInput(prompt string, options *ShellOptions) (string, error) {
 
 // Prompt the user for a yes/no response and return true if they entered yes.
 func PromptUserForYesNo(prompt string, options *ShellOptions) (bool, error) {
-	resp, err := PromptUserForInput(fmt.Sprintf("%s (y/n) ", prompt), options)
+	return FPromptUserForYesNo(os.Stdout, os.Stdin, prompt, options)
+}
+
+func FPromptUserForYesNo(out io.Writer, in io.Reader, prompt string, options *ShellOptions) (bool, error) {
+	resp, err := FPromptUserForInput(out, in, fmt.Sprintf("%s (y/n) ", prompt), options)
 
 	if err != nil {
 		return false, errors.WithStackTrace(err)
 	}
 
 	switch strings.ToLower(resp) {
-	case "y", "yes": return true, nil
-	default: return false, nil
+	case "y", "yes":
+		return true, nil
+	default:
+		return false, nil
 	}
 }
 

--- a/shell/prompt_test.go
+++ b/shell/prompt_test.go
@@ -1,0 +1,112 @@
+package shell
+
+import (
+	"bytes"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFPromptUserForInputReturnsYesOnNonInteractive(t *testing.T) {
+	t.Parallel()
+
+	opts := NewShellOptions()
+	opts.NonInteractive = true
+	resp, err := FPromptUserForInput(os.Stdout, os.Stdin, "", opts)
+
+	assert.Nil(t, err)
+	assert.Equal(t, resp, "yes")
+}
+
+func TestFPromptUserForInputStripsInput(t *testing.T) {
+	t.Parallel()
+
+	opts := NewShellOptions()
+	sout := ""
+	fakeStdout := bytes.NewBufferString(sout)
+	sin := "\t1.21 Gigawatts\t  \n"
+	fakeStdin := bytes.NewBufferString(sin)
+	resp, err := FPromptUserForInput(fakeStdout, fakeStdin, "", opts)
+
+	assert.Nil(t, err)
+	assert.Equal(t, resp, "1.21 Gigawatts")
+}
+
+func TestFPromptUserForInputAllowsEmptyString(t *testing.T) {
+	t.Parallel()
+
+	opts := NewShellOptions()
+	sout := ""
+	fakeStdout := bytes.NewBufferString(sout)
+	sin := "\n"
+	fakeStdin := bytes.NewBufferString(sin)
+	resp, err := FPromptUserForInput(fakeStdout, fakeStdin, "", opts)
+
+	assert.Nil(t, err)
+	assert.Equal(t, resp, "")
+}
+
+func TestFPromptUserForInputPrintsOutPrompt(t *testing.T) {
+	t.Parallel()
+
+	opts := NewShellOptions()
+	sout := ""
+	fakeStdout := bytes.NewBufferString(sout)
+	sin := "This is heavy\n"
+	fakeStdin := bytes.NewBufferString(sin)
+	_, err := FPromptUserForInput(fakeStdout, fakeStdin, "Great Scott!", opts)
+
+	assert.Nil(t, err)
+	assert.Contains(t, fakeStdout.String(), "Great Scott!")
+}
+
+func TestFPromptUserForYesNoPrintsOutPromptWithYN(t *testing.T) {
+	t.Parallel()
+
+	opts := NewShellOptions()
+	sout := ""
+	fakeStdout := bytes.NewBufferString(sout)
+	sin := "y\n"
+	fakeStdin := bytes.NewBufferString(sin)
+	_, err := FPromptUserForYesNo(fakeStdout, fakeStdin, "Great Scott!", opts)
+
+	assert.Nil(t, err)
+	assert.Contains(t, fakeStdout.String(), "Great Scott! (y/n)")
+}
+
+var yesNoPromptTests = []struct {
+	in  string
+	out bool
+}{
+	{"y", true},
+	{"YEs", true},
+	{"Y", true},
+	{"YES", true},
+	{"yes     ", true},
+	{"    yes", true},
+	{"\tyes", true},
+	{"yes\t", true},
+	{"ye", false},
+	{"", false},
+	{"delorean", false},
+	{"yes no", false},
+}
+
+func TestFPromptUserForYesNo(t *testing.T) {
+	for _, tt := range yesNoPromptTests {
+		t.Run(tt.in, func(t *testing.T) {
+			t.Parallel()
+
+			opts := NewShellOptions()
+			sout := ""
+			fakeStdout := bytes.NewBufferString(sout)
+			sin := tt.in + "\n"
+			fakeStdin := bytes.NewBufferString(sin)
+			resp, err := FPromptUserForYesNo(fakeStdout, fakeStdin, "Great Scott!", opts)
+
+			assert.Nil(t, err)
+			assert.Equal(t, resp, tt.out)
+		})
+	}
+}


### PR DESCRIPTION
This refactors the prompt functions to take in `io.Writer` and `io.Reader` so that they are testable. Also adds a bunch of unit tests for the two functions (`speakeasy` doesn't appear to be testable) as a part of that.