### PR TITLE
Wrapper around help text

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,12 @@ these built-in.
 
 ### entrypoint
 
-Most Gruntwork CLI apps should use this package to run their app, as it takes care of common tasks such as setting the
-proper exit code, rendering stack traces, and handling panics. Note that this package assumes you are using  
-[urfave/cli](https://github.com/urfave/cli), which is currently our library of choice for CLI apps.
+Most Gruntwork CLI apps should use this package to run their app, as it takes
+care of common tasks such as setting the proper exit code, rendering stack
+traces, handling panics, and rendering help text in a standard format. Note
+that this package assumes you are using
+[urfave/cli](https://github.com/urfave/cli), which is currently our library of
+choice for CLI apps.
 
 Here is the typical usage pattern in `main.go`:
 
@@ -45,8 +48,9 @@ import (
 var VERSION string
 
 func main() {
-      // Create a new CLI app with urfave/cli
-      app := cli.NewApp()
+      // Create a new CLI app. This will return a urfave/cli App with some
+      // common initialization.
+      app := entrypoint.NewApp()
     
       app.Name = "my-app"
       app.Author = "Gruntwork <www.gruntwork.io>"

--- a/entrypoint/entrypoint.go
+++ b/entrypoint/entrypoint.go
@@ -2,13 +2,24 @@ package entrypoint
 
 import (
 	"os"
+
 	"github.com/urfave/cli"
+
 	"github.com/gruntwork-io/gruntwork-cli/errors"
 	"github.com/gruntwork-io/gruntwork-cli/logging"
 )
 
 const defaultSuccessExitCode = 0
 const defaultErrorExitCode = 1
+
+// Wrapper around cli.NewApp that sets the help text printer.
+func NewApp() *cli.App {
+	cli.HelpPrinter = WrappedHelpPrinter
+	cli.AppHelpTemplate = CLI_APP_HELP_TEMPLATE
+	cli.CommandHelpTemplate = CLI_COMMAND_HELP_TEMPLATE
+	app := cli.NewApp()
+	return app
+}
 
 // Run the given app, handling errors, panics, and stack traces where possible
 func RunApp(app *cli.App) {

--- a/entrypoint/entrypoint_test.go
+++ b/entrypoint/entrypoint_test.go
@@ -1,0 +1,219 @@
+package entrypoint
+
+import (
+	"bytes"
+	"github.com/stretchr/testify/assert"
+	"github.com/urfave/cli"
+	"testing"
+)
+
+func TestEntrypointNewAppWrapsAppHelpPrinter(t *testing.T) {
+	app := createSampleApp()
+	fakeStdout := bytes.NewBufferString("")
+	app.Writer = fakeStdout
+	args := []string{"houston", "help"}
+	err := app.Run(args)
+	assert.Nil(t, err)
+	assert.Equal(t, fakeStdout.String(), EXPECTED_APP_HELP_OUT)
+}
+
+func TestEntrypointNewAppWrapsCommandHelpPrinter(t *testing.T) {
+	app := createSampleApp()
+	fakeStdout := bytes.NewBufferString("")
+	app.Writer = fakeStdout
+	args := []string{"houston", "help", "exec"}
+	err := app.Run(args)
+	assert.Nil(t, err)
+	assert.Equal(t, fakeStdout.String(), EXPECTED_EXEC_CMD_HELP_OUT)
+}
+
+func TestEntrypointNewAppHelpPrinterHonorsLineWidthVar(t *testing.T) {
+	HelpTextLineWidth = 120
+	app := createSampleApp()
+	fakeStdout := bytes.NewBufferString("")
+	app.Writer = fakeStdout
+	args := []string{"houston", "help"}
+	err := app.Run(args)
+	assert.Nil(t, err)
+	assert.Equal(t, fakeStdout.String(), EXPECTED_APP_HELP_OUT_120_LINES)
+}
+
+func TestEntrypointNewAppCommandHelpPrinterHonorsLineWidthVar(t *testing.T) {
+	HelpTextLineWidth = 120
+	app := createSampleApp()
+	fakeStdout := bytes.NewBufferString("")
+	app.Writer = fakeStdout
+	args := []string{"houston", "help", "exec"}
+	err := app.Run(args)
+	assert.Nil(t, err)
+	assert.Equal(t, fakeStdout.String(), EXPECTED_EXEC_CMD_HELP_OUT_120_LINES)
+}
+
+func noop(c *cli.Context) error { return nil }
+
+func createSampleApp() *cli.App {
+	app := NewApp()
+	app.Name = "houston"
+	app.HelpName = "houston"
+	app.Version = "v0.0.6"
+	app.Description = `A CLI tool for interacting with Gruntwork Houston that you can use to authenticate to AWS on the CLI and to SSH to your EC2 Instances.`
+
+	configFlag := cli.StringFlag{
+		Name:  "config, c",
+		Value: "~/.houston/houston.yml",
+		Usage: "The configuration file for houston",
+	}
+
+	portFlag := cli.IntFlag{
+		Name:  "port",
+		Value: 44444,
+		Usage: "The TCP port the http server is running on",
+	}
+
+	app.Commands = []cli.Command{
+		{
+			Name:      "exec",
+			Usage:     "Execute a command with temporary AWS credentials obtained by logging into Gruntwork Houston",
+			UsageText: "houston exec [options] <profile> -- <command>",
+			Description: `The exec command makes it easier to use CLI tools that need AWS credentials, such as aws, terraform, and packer. Here's how it works:
+
+   1. The first time you run this command for a <profile>, it will open your web browser and have you login to your Identity Provider (i.e., Google, ADFS, Okta). 
+   2. After login, the Identity Provider will redirect you to the Gruntwork Houston web console, where you will pick the AWS IAM Role you want to use. 
+   3. Gruntwork Houston will fetch temporary AWS credentials for this IAM Role and POST them back to houston CLI running on your computer.
+   4. The houston CLI will set those credentials as the appropriate environment variables and execute <command>.
+   5. The houston CLI will cache those credentials in memory, so all subsequent commands will execute without going through the login flow (until those credentials expire).
+
+Examples:
+
+   houston exec dev -- aws s3 ls
+   houston exec prod -- terraform apply
+   houston exec stage -- packer build server.json`,
+			Action: noop,
+			Flags:  []cli.Flag{configFlag, portFlag},
+		},
+		{
+			Name:      "ssh",
+			Usage:     "Connect to an EC2 instance via SSH with your public key.",
+			UsageText: "houston ssh [OPTIONS] <username>@<ip>",
+			Description: `Pre-requisites for using this command:
+
+   1. Install ssh-grunt on your EC2 Instances.
+   2. Configure each EC2 Instance to talk to your Gruntwork Houston deployment and to grant access to users with certain SSH Roles.
+   3. Have an admin grant you those SSH Roles in your Identity Provider (e.g., Google, ADFS, Okta).
+   4. Upload your public SSH key into Gruntwork Houston using its web console.
+
+Once all the above is taken care of, here is how the houston ssh command works:
+
+   1. If you haven't logged into the Gruntwork Houston web console recently, it will pop open your web browser and ask you to login.
+   2. Gruntwork Houston will cache the SSH Roles you have for a short time period. The need to update this cache is why the houston ssh command exists!
+   3. ssh-grunt runs a cron job on your EC2 Instances that creates local OS users for Houston users with specific SSH Roles.
+   4. The houston CLI on your computer will execute your native ssh command to connect to the EC2 Instance.
+   5. When the SSH request comes into the EC2 Instance, ssh-grunt fetches your public SSH key from Gruntwork Houston and gives it to the SSH daemon for verification. 
+
+Examples:
+
+   houston ssh grunt@11.22.33.44`,
+			Action: noop,
+			Flags:  []cli.Flag{configFlag, portFlag},
+		},
+		{
+			Name:        "configure",
+			Usage:       "Configure houston CLI options.",
+			UsageText:   "houston configure [options]",
+			Description: `The configure command can be used to setup or update the houston configuration file. When you run this command with no arguments, it will prompt you with the minimum required options for getting the CLI up and running. The prompt will include the current value as a default if the configuration file exists.`,
+			Action:      noop,
+			Flags:       []cli.Flag{configFlag},
+		},
+	}
+	return app
+}
+
+const EXPECTED_APP_HELP_OUT = `Usage: houston [--help] [--version] command [options] [args]
+
+A CLI tool for interacting with Gruntwork Houston that you can use to
+authenticate to AWS on the CLI and to SSH to your EC2 Instances.
+
+Commands:
+
+   exec       Execute a command with temporary AWS credentials obtained by
+              logging into Gruntwork Houston
+   ssh        Connect to an EC2 instance via SSH with your public key.
+   configure  Configure houston CLI options.
+   help, h    Shows a list of commands or help for one command
+
+`
+
+const EXPECTED_APP_HELP_OUT_120_LINES = `Usage: houston [--help] [--version] command [options] [args]
+
+A CLI tool for interacting with Gruntwork Houston that you can use to authenticate to AWS on the CLI and to SSH to your
+EC2 Instances.
+
+Commands:
+
+   exec       Execute a command with temporary AWS credentials obtained by logging into Gruntwork Houston
+   ssh        Connect to an EC2 instance via SSH with your public key.
+   configure  Configure houston CLI options.
+   help, h    Shows a list of commands or help for one command
+
+`
+
+const EXPECTED_EXEC_CMD_HELP_OUT = `Usage: houston exec [options] <profile> -- <command>
+
+The exec command makes it easier to use CLI tools that need AWS credentials,
+such as aws, terraform, and packer. Here's how it works:
+
+   1. The first time you run this command for a <profile>, it will open your web
+   browser and have you login to your Identity Provider (i.e., Google, ADFS,
+   Okta).
+   2. After login, the Identity Provider will redirect you to the Gruntwork
+   Houston web console, where you will pick the AWS IAM Role you want to use.
+   3. Gruntwork Houston will fetch temporary AWS credentials for this IAM Role
+   and POST them back to houston CLI running on your computer.
+   4. The houston CLI will set those credentials as the appropriate environment
+   variables and execute <command>.
+   5. The houston CLI will cache those credentials in memory, so all subsequent
+   commands will execute without going through the login flow (until those
+   credentials expire).
+
+Examples:
+
+   houston exec dev -- aws s3 ls
+   houston exec prod -- terraform apply
+   houston exec stage -- packer build server.json
+
+Options:
+
+   --config value, -c value  The configuration file for houston (default:
+                             "~/.houston/houston.yml")
+   --port value              The TCP port the http server is running on (default:
+                             44444)
+
+`
+
+const EXPECTED_EXEC_CMD_HELP_OUT_120_LINES = `Usage: houston exec [options] <profile> -- <command>
+
+The exec command makes it easier to use CLI tools that need AWS credentials, such as aws, terraform, and packer. Here's
+how it works:
+
+   1. The first time you run this command for a <profile>, it will open your web browser and have you login to your
+   Identity Provider (i.e., Google, ADFS, Okta).
+   2. After login, the Identity Provider will redirect you to the Gruntwork Houston web console, where you will pick the
+   AWS IAM Role you want to use.
+   3. Gruntwork Houston will fetch temporary AWS credentials for this IAM Role and POST them back to houston CLI running
+   on your computer.
+   4. The houston CLI will set those credentials as the appropriate environment variables and execute <command>.
+   5. The houston CLI will cache those credentials in memory, so all subsequent commands will execute without going
+   through the login flow (until those credentials expire).
+
+Examples:
+
+   houston exec dev -- aws s3 ls
+   houston exec prod -- terraform apply
+   houston exec stage -- packer build server.json
+
+Options:
+
+   --config value, -c value  The configuration file for houston (default: "~/.houston/houston.yml")
+   --port value              The TCP port the http server is running on (default: 44444)
+
+`

--- a/entrypoint/help_utils.go
+++ b/entrypoint/help_utils.go
@@ -18,14 +18,13 @@ var HelpTextLineWidth = 80
 // - Headers are title cased as opposed to all caps
 // - NAME, VERSION, AUTHOR, COPYRIGHT, and GLOBAL OPTIONS sections are removed
 // - Global options are displayed by name in the usage text
-const CLI_APP_HELP_TEMPLATE = `Usage: {{if .UsageText }}{{.UsageText}}{{else}}{{.HelpName}} {{range $index, $option := .VisibleFlags}}[{{$option.GetName | PrefixedFirstFlagName}}] {{end}}{{if .Commands}}command [options]{{end}} {{if .ArgsUsage}}{{.ArgsUsage}}{{else}}[args]{{end}}{{if .Description}}
+const CLI_APP_HELP_TEMPLATE = `Usage: {{if .UsageText }}{{.UsageText}}{{else}}{{.HelpName}} {{range $index, $option := .VisibleFlags}}[{{$option.GetName | PrefixedFirstFlagName}}] {{end}}{{if .Commands}}command [options]{{end}} {{if .ArgsUsage}}{{.ArgsUsage}}{{else}}[args]{{end}}{{end}}{{if .Description}}
 
 {{.Description}}{{end}}{{if .Commands}}
 
 Commands:
 
-{{range .Commands}}{{if not .HideHelp}}   {{join .Names ", "}}{{ "\t"}}{{.Usage}}{{ "\n" }}{{end}}{{end}}{{end}}{{if .VisibleFlags}}{{end}}
-`
+{{range .Commands}}{{if not .HideHelp}}   {{join .Names ", "}}{{ "\t"}}{{.Usage}}{{ "\n" }}{{end}}{{end}}{{end}}`
 
 // This version of the command help template has the following changes over the default ones:
 // - Headers are title cased as opposed to all caps
@@ -37,8 +36,7 @@ const CLI_COMMAND_HELP_TEMPLATE = `Usage: {{if .UsageText}}{{.UsageText}}{{else}
 Options:
 
    {{range .VisibleFlags}}{{.}}
-   {{end}}{{end}}
-`
+   {{end}}{{end}}`
 
 // HelpPrinter that will wrap the text at
 // HELP_TEXT_LINE_WIDTH characters, while preserving

--- a/entrypoint/help_utils.go
+++ b/entrypoint/help_utils.go
@@ -1,0 +1,155 @@
+package entrypoint
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"regexp"
+	"strings"
+	"text/tabwriter"
+	"text/template"
+	"unicode"
+)
+
+const HELP_TEXT_LINE_WIDTH = 80
+
+const CLI_APP_HELP_TEMPLATE = `Usage: {{.HelpName}} {{range $index, $option := .VisibleFlags}}[{{$option.GetName | PrefixedFirstFlagName}}] {{end}}{{if .Commands}}command [options]{{end}} {{if .ArgsUsage}}{{.ArgsUsage}}{{else}}[args]{{end}}{{if .Description}}
+
+{{.Description}}{{end}}{{if .Commands}}
+
+Commands:
+
+{{range .Commands}}{{if not .HideHelp}}   {{join .Names ", "}}{{ "\t"}}{{.Usage}}{{ "\n" }}{{end}}{{end}}{{end}}{{if .VisibleFlags}}{{end}}
+`
+
+const CLI_COMMAND_HELP_TEMPLATE = `Usage: {{if .UsageText}}{{.UsageText}}{{else}}{{.HelpName}}{{if .VisibleFlags}} [options]{{end}} {{if .ArgsUsage}}{{.ArgsUsage}}{{else}}[args]{{end}}{{end}}{{if .Description}}
+
+{{.Description}}{{end}}{{if .VisibleFlags}}
+
+Options:
+
+   {{range .VisibleFlags}}{{.}}
+   {{end}}{{end}}
+`
+
+// HelpPrinter that will wrap the text at
+// HELP_TEXT_LINE_WIDTH characters, while preserving
+// indentation and table tabs. Currently only works with
+// tables delimited by `\t` and with only 2 columns.
+func WrappedHelpPrinter(out io.Writer, templateString string, data interface{}) {
+	funcMap := template.FuncMap{
+		"join":                  strings.Join,
+		"PrefixedFirstFlagName": PrefixedFirstFlagName,
+	}
+
+	templ := template.Must(template.New("help").Funcs(funcMap).Parse(templateString))
+	rendered := bytes.NewBufferString("")
+	err := templ.Execute(rendered, data)
+	if err != nil {
+		return
+	}
+
+	writer := tabwriter.NewWriter(out, 0, 8, 2, ' ', 0)
+	for _, line := range strings.Split(rendered.String(), "\n") {
+		tab := HelpTableAwareDetermineIndent(line, "\t+")
+		wrappedLine := TabAwareWrapText(line, HELP_TEXT_LINE_WIDTH, tab)
+		fmt.Fprintln(writer, wrappedLine)
+	}
+	writer.Flush()
+}
+
+// Similar functionality to regexp.Split, but returns the delimited strings
+// with the trailing delimiter appended to it.
+// Example:
+//    re := regexp.MustCompile("\\s+")
+//    text := "one two three"
+//    out := SplitKeepDelimiter(re, text)
+//    out == ["one ", "two ", "three"]
+func SplitKeepDelimiter(re *regexp.Regexp, str string) (out []string) {
+	indexes := re.FindAllStringIndex(str, -1)
+	if indexes == nil {
+		return append(out, str)
+	}
+	cur := 0
+	for _, index := range indexes {
+		out = append(out, str[cur:index[1]])
+		cur = index[1]
+	}
+	if cur != len(str) {
+		out = append(out, str[cur:])
+	}
+	return out
+}
+
+// Wrap text to line width, while preserving any indentation
+func TabAwareWrapText(text string, lineWidth int, tab string) string {
+	wrapped := ""
+	re := regexp.MustCompile("\\s+")
+	words := SplitKeepDelimiter(re, text)
+	if len(words) == 0 {
+		return wrapped
+	}
+	// Keep on consuming words to current line until current line reaches
+	// lineWidth, at which point we start a new line. Keep in mind that word is
+	// word + whitespace to next word.
+	wrapped = words[0]
+	// NOTE: This tabLength is not exactly correct, as elastic
+	//       tabstops work with cells which may cause the tabs
+	//       to expand beyond 8 spaces. Nonetheless the goal
+	//       is to avoid overflowing beyond the lineWidth and
+	//       this should be a better approximation than 1
+	//       char.
+	tabLength := 8
+	currentLineLength := TabAwareStringLength(wrapped, tabLength)
+	for _, word := range words[1:] {
+		wordLength := TabAwareStringLength(word, tabLength)
+		trimmedWord := strings.TrimSpace(word)
+		trimmedWordLength := TabAwareStringLength(trimmedWord, tabLength)
+		if currentLineLength+trimmedWordLength > lineWidth {
+			wrapped = strings.TrimRightFunc(wrapped, unicode.IsSpace)
+			nextLine := tab + word
+			wrapped += "\n" + nextLine
+			currentLineLength = TabAwareStringLength(nextLine, tabLength)
+		} else {
+			wrapped += word
+			currentLineLength += wordLength
+		}
+	}
+	wrapped = strings.TrimRightFunc(wrapped, unicode.IsSpace)
+	return wrapped
+}
+
+func TabAwareStringLength(text string, tabLength int) int {
+	return len(strings.Replace(text, "\t", strings.Repeat(" ", tabLength), -1))
+}
+
+// Determine the tab string, accounting for textual tables.
+// Assumes only two columns, and there is a clear delimiter for them, like in
+// help text.
+func HelpTableAwareDetermineIndent(text string, tableDelimiterRe string) string {
+	// If we find a table, indent to second column
+	tableRe := regexp.MustCompile(tableDelimiterRe)
+	loc := tableRe.FindStringIndex(text)
+	if loc != nil {
+		return regexp.MustCompile("[^\\s]").ReplaceAllString(text[:loc[1]], " ")
+	}
+
+	// ... otherwise, indent one
+	re := regexp.MustCompile("^\\s*")
+	loc = re.FindStringIndex(text)
+	if loc == nil {
+		return ""
+	}
+	return text[loc[0]:loc[1]]
+}
+
+func PrefixedFirstFlagName(fullName string) string {
+	names := strings.Split(fullName, ",")
+	firstName := names[0]
+	trimmedFirstName := strings.TrimSpace(firstName)
+	if len(trimmedFirstName) == 1 {
+		return "-" + trimmedFirstName
+	} else {
+		return "--" + trimmedFirstName
+	}
+}

--- a/entrypoint/help_utils_test.go
+++ b/entrypoint/help_utils_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 )
 
-var splitKeepDelimiterTests = []struct {
+var splitAfterTests = []struct {
 	in  string
 	out []string
 }{
@@ -18,16 +18,16 @@ var splitKeepDelimiterTests = []struct {
 	{"\nonetwothree", []string{"\n", "onetwothree"}},
 }
 
-func TestSplitKeepDelimiter(t *testing.T) {
-	for _, tt := range splitKeepDelimiterTests {
+func TestRegexpSplitAfterDelimiter(t *testing.T) {
+	for _, tt := range splitAfterTests {
 		t.Run(tt.in, func(t *testing.T) {
 			re := regexp.MustCompile("\\s+")
-			assert.Equal(t, SplitKeepDelimiter(re, tt.in), tt.out)
+			assert.Equal(t, RegexpSplitAfter(re, tt.in), tt.out)
 		})
 	}
 }
 
-var determineTabTests = []struct {
+var determineIndentTests = []struct {
 	in    string
 	delim string
 	out   string
@@ -38,10 +38,15 @@ var determineTabTests = []struct {
 	{"  one\ttwo", "\t", "     \t"},
 	{"  \ttwo", "\t", "  \t"},
 	{"  hello|world", "\\|", "        "},
+	{
+		"   exec\tExecute a command with temporary AWS credentials obtained by logging into Gruntwork Houston",
+		"\t",
+		"       \t",
+	},
 }
 
 func TestHelpTableAwareDetermineIndent(t *testing.T) {
-	for _, tt := range determineTabTests {
+	for _, tt := range determineIndentTests {
 		t.Run(tt.in, func(t *testing.T) {
 			assert.Equal(t, HelpTableAwareDetermineIndent(tt.in, tt.delim), tt.out)
 		})
@@ -49,33 +54,43 @@ func TestHelpTableAwareDetermineIndent(t *testing.T) {
 }
 
 var wrapTextTests = []struct {
-	in  string
-	out string
-	tab string
+	in        string
+	out       string
+	indent    string
+	lineWidth int
 }{
 	{
 		"    Great Scott!",
 		"    Great\n    Scott!",
 		"    ",
+		15,
 	},
 	{
 		"You made a time machine out of a Delorean!?",
 		"You made a time\nmachine out of\na Delorean!?",
 		"",
+		15,
 	},
 	{
 		"  fc\tThe box that",
 		"  fc\tThe\n    \tbox\n    \tthat",
 		"    \t",
+		15,
+	},
+	{
+		"   exec\tExecute a command with temporary AWS credentials obtained by logging into Gruntwork Houston",
+		"   exec\tExecute a command with temporary AWS credentials obtained by\n       \tlogging into Gruntwork Houston",
+		"       \t",
+		80,
 	},
 }
 
-func TestTabAwareWrapText(t *testing.T) {
+func TestIndentAwareWrapText(t *testing.T) {
 	for _, tt := range wrapTextTests {
 		t.Run(tt.in, func(t *testing.T) {
 			assert.Equal(
 				t,
-				TabAwareWrapText(tt.in, 15, tt.tab),
+				IndentAwareWrapText(tt.in, tt.lineWidth, tt.indent),
 				tt.out)
 		})
 	}

--- a/entrypoint/help_utils_test.go
+++ b/entrypoint/help_utils_test.go
@@ -1,0 +1,82 @@
+package entrypoint
+
+import (
+	"regexp"
+
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+var splitKeepDelimiterTests = []struct {
+	in  string
+	out []string
+}{
+	{"one two three", []string{"one ", "two ", "three"}},
+	{"one\ttwo\tthree", []string{"one\t", "two\t", "three"}},
+	{"one\n two    three\t\n ", []string{"one\n ", "two    ", "three\t\n "}},
+	{"onetwothree\n", []string{"onetwothree\n"}},
+	{"\nonetwothree", []string{"\n", "onetwothree"}},
+}
+
+func TestSplitKeepDelimiter(t *testing.T) {
+	for _, tt := range splitKeepDelimiterTests {
+		t.Run(tt.in, func(t *testing.T) {
+			re := regexp.MustCompile("\\s+")
+			assert.Equal(t, SplitKeepDelimiter(re, tt.in), tt.out)
+		})
+	}
+}
+
+var determineTabTests = []struct {
+	in    string
+	delim string
+	out   string
+}{
+	{"   o three", "\t", "   "},
+	{"\to  three", "\t", "\t"},
+	{"o three", "\t", ""},
+	{"  one\ttwo", "\t", "     \t"},
+	{"  \ttwo", "\t", "  \t"},
+	{"  hello|world", "\\|", "        "},
+}
+
+func TestHelpTableAwareDetermineIndent(t *testing.T) {
+	for _, tt := range determineTabTests {
+		t.Run(tt.in, func(t *testing.T) {
+			assert.Equal(t, HelpTableAwareDetermineIndent(tt.in, tt.delim), tt.out)
+		})
+	}
+}
+
+var wrapTextTests = []struct {
+	in  string
+	out string
+	tab string
+}{
+	{
+		"    Great Scott!",
+		"    Great\n    Scott!",
+		"    ",
+	},
+	{
+		"You made a time machine out of a Delorean!?",
+		"You made a time\nmachine out of\na Delorean!?",
+		"",
+	},
+	{
+		"  fc\tThe box that",
+		"  fc\tThe\n    \tbox\n    \tthat",
+		"    \t",
+	},
+}
+
+func TestTabAwareWrapText(t *testing.T) {
+	for _, tt := range wrapTextTests {
+		t.Run(tt.in, func(t *testing.T) {
+			assert.Equal(
+				t,
+				TabAwareWrapText(tt.in, 15, tt.tab),
+				tt.out)
+		})
+	}
+}


### PR DESCRIPTION
This adds the wrapped help text printer to `gruntwork-cli` and a function to create a new `cli.App` that takes advantage of it.

## Sample output:

### Main help
Original
```
NAME:
   houston - A CLI tool for interacting with Gruntwork Houston that you can use to authenticate to AWS on the CLI and to SSH to your EC2 Instances.

USAGE:
   houston [global options] command [command options] [arguments...]

VERSION:
   snapshot

COMMANDS:
     exec       Execute a command with temporary AWS credentials obtained by logging into Gruntwork Houston
     ssh        Connect to an EC2 instance via SSH with your public key.
     configure  Configure houston CLI options.
     profiles   Show a status of all the defined profiles.
     start      Start the background HTTP server process so it can cache your AWS credentials. Note: the exec command starts the HTTP server process automatically.
     stop       Stop the background HTTP server process.
     status     Show the status of the background HTTP server process.
     help, h    Shows a list of commands or help for one command

GLOBAL OPTIONS:
   --help, -h     show help
   --version, -v  print the version
```

New:
```
Usage: houston [--help] [--version] command [options] [args]

A CLI tool for interacting with Gruntwork Houston that you can use to
authenticate to AWS on the CLI and to SSH to your EC2 Instances.

Commands:

   exec       Execute a command with temporary AWS credentials obtained by
              logging into Gruntwork Houston
   ssh        Connect to an EC2 instance via SSH with your public key.
   configure  Configure houston CLI options.
   profiles   Show a status of all the defined profiles.
   start      Start the background HTTP server process so it can cache your
              AWS credentials. Note: the exec command starts the HTTP server
              process automatically.
   stop       Stop the background HTTP server process.
   status     Show the status of the background HTTP server process.
   help, h    Shows a list of commands or help for one command
```

### Command help
Original:
```
NAME:
   houston exec - Execute a command with temporary AWS credentials obtained by logging into Gruntwork Houston

USAGE:
   houston exec [OPTIONS] <profile> -- <command>

DESCRIPTION:
   The exec command makes it easier to use CLI tools that need AWS credentials, such as aws, terraform, and packer. Here's how it works:

   1. The first time you run this command for a <profile>, it will open your web browser and have you login to your Identity Provider (i.e., Google, ADFS, Okta).
   2. After login, the Identity Provider will redirect you to the Gruntwork Houston web console, where you will pick the AWS IAM Role you want to use.
   3. Gruntwork Houston will fetch temporary AWS credentials for this IAM Role and POST them back to houston CLI running on your computer.
   4. The houston CLI will set those credentials as the appropriate environment variables and execute <command>.
   5. The houston CLI will cache those credentials in memory, so all subsequent commands will execute without going through the login flow (until those credentials expire).

EXAMPLES:

   houston exec dev -- aws s3 ls
   houston exec prod -- terraform apply
   houston exec stage -- packer build server.json

OPTIONS:
   --config value, -c value  The configuration file for houston (default: "/Users/yoriy/.houston/houston.yml")
   --port value              The TCP port the http server is running on (default: 41170)
```

New:
```
Usage: houston exec [options] <profile> -- <command>

The exec command makes it easier to use CLI tools that need AWS credentials,
such as aws, terraform, and packer. Here's how it works:

  1. The first time you run this command for a <profile>, it will open your web
  browser and have you login to your Identity Provider (i.e., Google, ADFS,
  Okta).
  2. After login, the Identity Provider will redirect you to the Gruntwork
  Houston web console, where you will pick the AWS IAM Role you want to use.
  3. Gruntwork Houston will fetch temporary AWS credentials for this IAM Role
  and POST them back to houston CLI running on your computer.
  4. The houston CLI will set those credentials as the appropriate environment
  variables and execute <command>.
  5. The houston CLI will cache those credentials in memory, so all subsequent
  commands will execute without going through the login flow (until those
  credentials expire).

Examples:

   houston exec dev -- aws s3 ls
   houston exec prod -- terraform apply
   houston exec stage -- packer build server.json

Options:

   --config value, -c value  The configuration file for houston (default:
                             "/Users/yoriy/.houston/houston.yml")
   --port value              The TCP port the http server is running on (default:
                             41170)
```