### PR TITLE
Add concept of sensitive args

### DIFF
--- a/shell/cmd.go
+++ b/shell/cmd.go
@@ -1,18 +1,23 @@
 package shell
 
 import (
-	"os/exec"
-	"os"
-	"strings"
-	"github.com/gruntwork-io/gruntwork-cli/errors"
-	"io"
 	"bufio"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/gruntwork-io/gruntwork-cli/errors"
 )
 
 // Run the specified shell command with the specified arguments. Connect the command's stdin, stdout, and stderr to
 // the currently running app.
-func RunShellCommand(options *ShellOptions, command string, args ... string) error {
-	options.Logger.Infof("Running command: %s %s", command, strings.Join(args, " "))
+func RunShellCommand(options *ShellOptions, command string, args ...string) error {
+	if options.SensitiveArgs {
+		options.Logger.Infof("Running command: %s (args redacted)", command)
+	} else {
+		options.Logger.Infof("Running command: %s %s", command, strings.Join(args, " "))
+	}
 
 	cmd := exec.Command(command, args...)
 
@@ -27,8 +32,12 @@ func RunShellCommand(options *ShellOptions, command string, args ... string) err
 }
 
 // Run the specified shell command with the specified arguments. Return its stdout and stderr as a string
-func RunShellCommandAndGetOutput(options *ShellOptions, command string, args ... string) (string, error) {
-	options.Logger.Infof("Running command: %s %s", command, strings.Join(args, " "))
+func RunShellCommandAndGetOutput(options *ShellOptions, command string, args ...string) (string, error) {
+	if options.SensitiveArgs {
+		options.Logger.Infof("Running command: %s (args redacted)", command)
+	} else {
+		options.Logger.Infof("Running command: %s %s", command, strings.Join(args, " "))
+	}
 
 	cmd := exec.Command(command, args...)
 
@@ -41,8 +50,12 @@ func RunShellCommandAndGetOutput(options *ShellOptions, command string, args ...
 
 // Run the specified shell command with the specified arguments. Return its stdout and stderr as a string and also
 // stream stdout and stderr to the OS stdout/stderr
-func RunShellCommandAndGetAndStreamOutput(options *ShellOptions, command string, args ... string) (string, error) {
-	options.Logger.Infof("Running command: %s %s", command, strings.Join(args, " "))
+func RunShellCommandAndGetAndStreamOutput(options *ShellOptions, command string, args ...string) (string, error) {
+	if options.SensitiveArgs {
+		options.Logger.Infof("Running command: %s (args redacted)", command)
+	} else {
+		options.Logger.Infof("Running command: %s %s", command, strings.Join(args, " "))
+	}
 
 	cmd := exec.Command(command, args...)
 

--- a/shell/cmd_test.go
+++ b/shell/cmd_test.go
@@ -3,7 +3,6 @@ package shell
 import (
 	"bytes"
 	"github.com/stretchr/testify/assert"
-	"strings"
 	"testing"
 
 	"github.com/gruntwork-io/gruntwork-cli/logging"
@@ -53,8 +52,8 @@ func TestSensitiveArgsTrueHidesOnRunShellCommand(t *testing.T) {
 	options.Logger = logger
 
 	assert.Nil(t, RunShellCommand(options, "echo", "hi"))
-	assert.False(t, strings.Contains(buffer.String(), "hi"))
-	assert.True(t, strings.Contains(buffer.String(), "echo"))
+	assert.NotContains(t, buffer.String(), "hi")
+	assert.Contains(t, buffer.String(), "echo")
 }
 
 // Test that when SensitiveArgs is false, log the args
@@ -68,8 +67,8 @@ func TestSensitiveArgsFalseShowsOnRunShellCommand(t *testing.T) {
 	options.Logger = logger
 
 	assert.Nil(t, RunShellCommand(options, "echo", "hi"))
-	assert.True(t, strings.Contains(buffer.String(), "hi"))
-	assert.True(t, strings.Contains(buffer.String(), "echo"))
+	assert.Contains(t, buffer.String(), "hi")
+	assert.Contains(t, buffer.String(), "echo")
 }
 
 // Test that when SensitiveArgs is true, do not log the args
@@ -85,8 +84,8 @@ func TestSensitiveArgsTrueHidesOnRunShellCommandAndGetOutput(t *testing.T) {
 
 	_, err := RunShellCommandAndGetOutput(options, "echo", "hi")
 	assert.Nil(t, err)
-	assert.False(t, strings.Contains(buffer.String(), "hi"))
-	assert.True(t, strings.Contains(buffer.String(), "echo"))
+	assert.NotContains(t, buffer.String(), "hi")
+	assert.Contains(t, buffer.String(), "echo")
 }
 
 // Test that when SensitiveArgs is false, log the args
@@ -101,6 +100,6 @@ func TestSensitiveArgsFalseShowsOnRunShellCommandAndGetOutput(t *testing.T) {
 
 	_, err := RunShellCommandAndGetOutput(options, "echo", "hi")
 	assert.Nil(t, err)
-	assert.True(t, strings.Contains(buffer.String(), "hi"))
-	assert.True(t, strings.Contains(buffer.String(), "echo"))
+	assert.Contains(t, buffer.String(), "hi")
+	assert.Contains(t, buffer.String(), "echo")
 }

--- a/shell/cmd_test.go
+++ b/shell/cmd_test.go
@@ -1,8 +1,12 @@
 package shell
 
 import (
-	"testing"
+	"bytes"
 	"github.com/stretchr/testify/assert"
+	"strings"
+	"testing"
+
+	"github.com/gruntwork-io/gruntwork-cli/logging"
 )
 
 func TestRunShellCommand(t *testing.T) {
@@ -35,4 +39,68 @@ func TestCommandInstalledOnInvalidCommand(t *testing.T) {
 	t.Parallel()
 
 	assert.False(t, CommandInstalled("not-a-real-command"))
+}
+
+// Test that when SensitiveArgs is true, do not log the args
+func TestSensitiveArgsTrueHidesOnRunShellCommand(t *testing.T) {
+	t.Parallel()
+
+	buffer := bytes.NewBufferString("")
+	logger := logging.GetLogger("")
+	logger.Out = buffer
+	options := NewShellOptions()
+	options.SensitiveArgs = true
+	options.Logger = logger
+
+	assert.Nil(t, RunShellCommand(options, "echo", "hi"))
+	assert.False(t, strings.Contains(buffer.String(), "hi"))
+	assert.True(t, strings.Contains(buffer.String(), "echo"))
+}
+
+// Test that when SensitiveArgs is false, log the args
+func TestSensitiveArgsFalseShowsOnRunShellCommand(t *testing.T) {
+	t.Parallel()
+
+	buffer := bytes.NewBufferString("")
+	logger := logging.GetLogger("")
+	logger.Out = buffer
+	options := NewShellOptions()
+	options.Logger = logger
+
+	assert.Nil(t, RunShellCommand(options, "echo", "hi"))
+	assert.True(t, strings.Contains(buffer.String(), "hi"))
+	assert.True(t, strings.Contains(buffer.String(), "echo"))
+}
+
+// Test that when SensitiveArgs is true, do not log the args
+func TestSensitiveArgsTrueHidesOnRunShellCommandAndGetOutput(t *testing.T) {
+	t.Parallel()
+
+	buffer := bytes.NewBufferString("")
+	logger := logging.GetLogger("")
+	logger.Out = buffer
+	options := NewShellOptions()
+	options.SensitiveArgs = true
+	options.Logger = logger
+
+	_, err := RunShellCommandAndGetOutput(options, "echo", "hi")
+	assert.Nil(t, err)
+	assert.False(t, strings.Contains(buffer.String(), "hi"))
+	assert.True(t, strings.Contains(buffer.String(), "echo"))
+}
+
+// Test that when SensitiveArgs is false, log the args
+func TestSensitiveArgsFalseShowsOnRunShellCommandAndGetOutput(t *testing.T) {
+	t.Parallel()
+
+	buffer := bytes.NewBufferString("")
+	logger := logging.GetLogger("")
+	logger.Out = buffer
+	options := NewShellOptions()
+	options.Logger = logger
+
+	_, err := RunShellCommandAndGetOutput(options, "echo", "hi")
+	assert.Nil(t, err)
+	assert.True(t, strings.Contains(buffer.String(), "hi"))
+	assert.True(t, strings.Contains(buffer.String(), "echo"))
 }

--- a/shell/options.go
+++ b/shell/options.go
@@ -1,20 +1,22 @@
 package shell
 
 import (
-	"github.com/sirupsen/logrus"
 	"github.com/gruntwork-io/gruntwork-cli/logging"
+	"github.com/sirupsen/logrus"
 )
 
 type ShellOptions struct {
 	NonInteractive bool
 	Logger         *logrus.Logger
 	WorkingDir     string
+	SensitiveArgs  bool // If true, will not log the arguments to the command
 }
 
 func NewShellOptions() *ShellOptions {
 	return &ShellOptions{
 		NonInteractive: false,
-		Logger: logging.GetLogger(""),
-		WorkingDir: ".",
+		Logger:         logging.GetLogger(""),
+		WorkingDir:     ".",
+		SensitiveArgs:  false,
 	}
 }


### PR DESCRIPTION
Right now we log the command string when we call commands using `RunShellCommand`, which is really nice for debugging purposes. However, sometimes this should be suppressed because the args might include sensitive data. For example, when scripting calls to `openssl` to create certs, the password can only be passed in via the command line when avoiding the prompt.

The solution proposed and implemented here is to add a new shell option that marks the commands as having sensitive args, which is used to suppress logging the args.