### PR TITLE
Configurable stack traces

### DIFF
--- a/entrypoint/entrypoint.go
+++ b/entrypoint/entrypoint.go
@@ -11,6 +11,7 @@ import (
 
 const defaultSuccessExitCode = 0
 const defaultErrorExitCode = 1
+const debugEnvironmentVarName = "GRUNTWORK_DEBUG"
 
 // Wrapper around cli.NewApp that sets the help text printer.
 func NewApp() *cli.App {
@@ -34,11 +35,18 @@ func RunApp(app *cli.App) {
 }
 
 // If there is an error, display it in the console and exit with a non-zero exit code. Otherwise, exit 0.
+// Note that if the GRUNTWORK_DEBUG environment variable is set to 1, this will print out the stack trace.
 func checkForErrorsAndExit(err error) {
 	exitCode := defaultSuccessExitCode
+	isDebugMode := os.Getenv(debugEnvironmentVarName) == "1"
 
 	if err != nil {
-		logging.GetLogger("").WithError(err).Error(errors.PrintErrorWithStackTrace(err))
+		logger := logging.GetLogger("").WithError(err)
+		if isDebugMode {
+			logger.Error(errors.PrintErrorWithStackTrace(err))
+		} else {
+			logger.Error(errors.Unwrap(err))
+		}
 
 		errorWithExitCode, isErrorWithExitCode := err.(errors.ErrorWithExitCode)
 		if isErrorWithExitCode {

--- a/entrypoint/entrypoint.go
+++ b/entrypoint/entrypoint.go
@@ -45,7 +45,7 @@ func checkForErrorsAndExit(err error) {
 		if isDebugMode {
 			logging.GetLogger("").WithError(err).Error(errors.PrintErrorWithStackTrace(err))
 		} else {
-			fmt.Fprintf(os.Stderr, "ERROR: %s", errors.Unwrap(err))
+			fmt.Fprintf(os.Stderr, "ERROR: %s\n", errors.Unwrap(err))
 		}
 
 		errorWithExitCode, isErrorWithExitCode := err.(errors.ErrorWithExitCode)

--- a/entrypoint/entrypoint.go
+++ b/entrypoint/entrypoint.go
@@ -1,6 +1,7 @@
 package entrypoint
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/urfave/cli"
@@ -41,11 +42,10 @@ func checkForErrorsAndExit(err error) {
 	isDebugMode := os.Getenv(debugEnvironmentVarName) == "1"
 
 	if err != nil {
-		logger := logging.GetLogger("").WithError(err)
 		if isDebugMode {
-			logger.Error(errors.PrintErrorWithStackTrace(err))
+			logging.GetLogger("").WithError(err).Error(errors.PrintErrorWithStackTrace(err))
 		} else {
-			logger.Error(errors.Unwrap(err))
+			fmt.Fprintf(os.Stderr, "ERROR: %s", errors.Unwrap(err))
 		}
 
 		errorWithExitCode, isErrorWithExitCode := err.(errors.ErrorWithExitCode)

--- a/entrypoint/entrypoint.go
+++ b/entrypoint/entrypoint.go
@@ -36,10 +36,10 @@ func RunApp(app *cli.App) {
 }
 
 // If there is an error, display it in the console and exit with a non-zero exit code. Otherwise, exit 0.
-// Note that if the GRUNTWORK_DEBUG environment variable is set to 1, this will print out the stack trace.
+// Note that if the GRUNTWORK_DEBUG environment variable is set, this will print out the stack trace.
 func checkForErrorsAndExit(err error) {
 	exitCode := defaultSuccessExitCode
-	isDebugMode := os.Getenv(debugEnvironmentVarName) == "1"
+	isDebugMode := os.Getenv(debugEnvironmentVarName) != ""
 
 	if err != nil {
 		if isDebugMode {

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -29,7 +29,7 @@ func WithStackTrace(err error) error {
 // Wrap the given error in an Error type that contains the stack trace and has the given message prepended as part of
 // the error message. If the given error already has a stack trace, it is used directly. If the given error is nil,
 // return nil.
-func WithStackTraceAndPrefix(err error, message string, args ... interface{}) error {
+func WithStackTraceAndPrefix(err error, message string, args ...interface{}) error {
 	if err == nil {
 		return nil
 	}
@@ -65,8 +65,10 @@ func PrintErrorWithStackTrace(err error) string {
 	}
 
 	switch underlyingErr := err.(type) {
-	case *goerrors.Error: return underlyingErr.ErrorStack()
-	default: return err.Error()
+	case *goerrors.Error:
+		return underlyingErr.ErrorStack()
+	default:
+		return err.Error()
 	}
 }
 


### PR DESCRIPTION
The stack traces are very useful, but as a customer facing CLI, it can be rather verbose and is useless unless they know the source code.

This introduces the concept of a debug mode for configuring when to print out the stack trace. Now the command will only print out stack traces when run with `GRUNTWORK_DEBUG=1`.

Note: I couldn't find a good way to unit test this, given that `checkForErrorsAndExit` kills the process. For now, here is the manual test demo:

Without env:
```
%~> go run main.go                                                                                                                                        [0]
ERRO[2018-11-28T11:31:10-08:00] --aws-region is required                      error="--aws-region is required"
exit status 1
```

With env:
```
%~> GRUNTWORK_DEBUG=1 go run main.go                                                                                                                      [1]
ERRO[2018-11-28T11:31:21-08:00] *errors.errorString --aws-region is required
/Users/yoriy/go/src/github.com/gruntwork-io/package-k8s/modules/k8s-binaries/cmd/eks-configure-kubectl/main.go:111 (0x114eb33)
        run: return gruntworkErrors.WithStackTrace(err)
/Users/yoriy/go/src/github.com/gruntwork-io/package-k8s/modules/k8s-binaries/vendor/github.com/urfave/cli/app.go:490 (0x11225c8)
        HandleAction: return a(context)
/Users/yoriy/go/src/github.com/gruntwork-io/package-k8s/modules/k8s-binaries/vendor/github.com/urfave/cli/app.go:264 (0x112083d)
        (*App).Run: err = HandleAction(a.Action, context)
/Users/yoriy/go/src/github.com/gruntwork-io/package-k8s/modules/k8s-binaries/vendor/github.com/gruntwork-io/gruntwork-cli/entrypoint/entrypoint.go:33 (0x11440f6)
        RunApp: err := app.Run(os.Args)
/Users/yoriy/go/src/github.com/gruntwork-io/package-k8s/modules/k8s-binaries/cmd/eks-configure-kubectl/main.go:174 (0x114ef3c)
        main: entrypoint.RunApp(app)
/usr/local/Cellar/go/1.11.2/libexec/src/runtime/proc.go:201 (0x102aba7)
        main: fn()
/usr/local/Cellar/go/1.11.2/libexec/src/runtime/asm_amd64.s:1333 (0x1055a51)
        goexit: BYTE    $0x90   // NOP  error="--aws-region is required"
exit status 1
```