### PR TITLE
Use the same format for nested commands

### DIFF
--- a/entrypoint/entrypoint.go
+++ b/entrypoint/entrypoint.go
@@ -19,6 +19,7 @@ func NewApp() *cli.App {
 	cli.HelpPrinter = WrappedHelpPrinter
 	cli.AppHelpTemplate = CLI_APP_HELP_TEMPLATE
 	cli.CommandHelpTemplate = CLI_COMMAND_HELP_TEMPLATE
+	cli.SubcommandHelpTemplate = CLI_APP_HELP_TEMPLATE
 	app := cli.NewApp()
 	return app
 }


### PR DESCRIPTION
If we have nested commands (e.g `kubergrunt eks configure`), then the help text for the second level is still using the default `urfave` template. This updates it to use the same one as the app level:

Original:

```
NAME:
   kubergrunt eks - Helper commands to configure EKS, including setting up operator machines to authenticate with EKS.

USAGE:
   kubergrunt eks command [command options] [arguments...]

COMMANDS:
     configure  Set up kubectl to be able to authenticate with EKS.
     token      Get token for Kubernetes using AWS IAM credential.

OPTIONS:
   --help, -h  show help

```

Updated:

```
Usage: kubergrunt eks [--help] command [options] [args]

Helper commands to configure EKS, including setting up operator machines to authenticate with EKS.

Commands:

   configure  Set up kubectl to be able to authenticate with EKS.
   token      Get token for Kubernetes using AWS IAM credential.
   help, h    Shows a list of commands or help for one command

```