### PR TITLE
Add BatchListIntoGroupsOf

### DIFF
--- a/collections/lists.go
+++ b/collections/lists.go
@@ -22,3 +22,26 @@ func RemoveElementFromList(list []string, element string) []string {
 	return out
 }
 
+// BatchListIntoGroupsOf will group the provided string slice into groups of size n, with the last of being truncated to
+// the remaining count of strings.  Returns nil if n is <= 0
+func BatchListIntoGroupsOf(slice []string, batchSize int) [][]string {
+	if batchSize <= 0 {
+		return nil
+	}
+
+	// We make a copy of the slice here so that we can modify it
+	copyOfSlice := make([]string, len(slice))
+	copy(copyOfSlice, slice)
+
+	// Taken from SliceTricks: https://github.com/golang/go/wiki/SliceTricks#batching-with-minimal-allocation
+	// Intuition: We repeatedly slice off batchSize elements from copyOfSlice and append it to the output, until there
+	// is not enough.
+	output := [][]string{}
+	for batchSize < len(copyOfSlice) {
+		copyOfSlice, output = copyOfSlice[batchSize:], append(output, copyOfSlice[0:batchSize:batchSize])
+	}
+	if len(copyOfSlice) > 0 {
+		output = append(output, copyOfSlice)
+	}
+	return output
+}

--- a/collections/lists.go
+++ b/collections/lists.go
@@ -22,6 +22,13 @@ func RemoveElementFromList(list []string, element string) []string {
 	return out
 }
 
+// MakeCopyOfList will return a new list that is a copy of the given list.
+func MakeCopyOfList(list []string) []string {
+	copyOfList := make([]string, len(list))
+	copy(copyOfList, list)
+	return copyOfList
+}
+
 // BatchListIntoGroupsOf will group the provided string slice into groups of size n, with the last of being truncated to
 // the remaining count of strings.  Returns nil if n is <= 0
 func BatchListIntoGroupsOf(slice []string, batchSize int) [][]string {
@@ -29,19 +36,15 @@ func BatchListIntoGroupsOf(slice []string, batchSize int) [][]string {
 		return nil
 	}
 
-	// We make a copy of the slice here so that we can modify it
-	copyOfSlice := make([]string, len(slice))
-	copy(copyOfSlice, slice)
-
 	// Taken from SliceTricks: https://github.com/golang/go/wiki/SliceTricks#batching-with-minimal-allocation
-	// Intuition: We repeatedly slice off batchSize elements from copyOfSlice and append it to the output, until there
+	// Intuition: We repeatedly slice off batchSize elements from slice and append it to the output, until there
 	// is not enough.
 	output := [][]string{}
-	for batchSize < len(copyOfSlice) {
-		copyOfSlice, output = copyOfSlice[batchSize:], append(output, copyOfSlice[0:batchSize:batchSize])
+	for batchSize < len(slice) {
+		slice, output = slice[batchSize:], append(output, slice[0:batchSize:batchSize])
 	}
-	if len(copyOfSlice) > 0 {
-		output = append(output, copyOfSlice)
+	if len(slice) > 0 {
+		output = append(output, slice)
 	}
 	return output
 }

--- a/collections/lists_test.go
+++ b/collections/lists_test.go
@@ -6,6 +6,12 @@ import (
 	"testing"
 )
 
+func TestMakeCopyOfListMakesACopy(t *testing.T) {
+	original := []string{"foo", "bar", "baz"}
+	copyOfList := MakeCopyOfList(original)
+	assert.Equal(t, original, copyOfList)
+}
+
 func TestListContainsElement(t *testing.T) {
 	t.Parallel()
 
@@ -112,7 +118,10 @@ func TestBatchListIntoGroupsOf(t *testing.T) {
 	for idx, testCase := range testCases {
 		t.Run(fmt.Sprintf("%s_%d", t.Name(), idx), func(t *testing.T) {
 			t.Parallel()
+			original := MakeCopyOfList(testCase.stringList)
 			assert.Equal(t, BatchListIntoGroupsOf(testCase.stringList, testCase.n), testCase.result)
+			// Make sure the function doesn't modify the original list
+			assert.Equal(t, testCase.stringList, original)
 		})
 	}
 }

--- a/collections/lists_test.go
+++ b/collections/lists_test.go
@@ -1,15 +1,16 @@
 package collections
 
 import (
-	"testing"
+	"fmt"
 	"github.com/stretchr/testify/assert"
+	"testing"
 )
 
 func TestListContainsElement(t *testing.T) {
 	t.Parallel()
 
 	testCases := []struct {
-		list	 []string
+		list     []string
 		element  string
 		expected bool
 	}{
@@ -31,7 +32,7 @@ func TestRemoveElementFromList(t *testing.T) {
 	t.Parallel()
 
 	testCases := []struct {
-		list	 []string
+		list     []string
 		element  string
 		expected []string
 	}{
@@ -50,3 +51,68 @@ func TestRemoveElementFromList(t *testing.T) {
 	}
 }
 
+func TestBatchListIntoGroupsOf(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		stringList []string
+		n          int
+		result     [][]string
+	}{
+		{
+			[]string{"macaroni", "gentoo", "magellanic", "adelie", "little", "king", "emperor"},
+			2,
+			[][]string{
+				[]string{"macaroni", "gentoo"},
+				[]string{"magellanic", "adelie"},
+				[]string{"little", "king"},
+				[]string{"emperor"},
+			},
+		},
+		{
+			[]string{"macaroni", "gentoo", "magellanic", "adelie", "king", "emperor"},
+			2,
+			[][]string{
+				[]string{"macaroni", "gentoo"},
+				[]string{"magellanic", "adelie"},
+				[]string{"king", "emperor"},
+			},
+		},
+		{
+			[]string{"macaroni", "gentoo", "magellanic"},
+			5,
+			[][]string{
+				[]string{"macaroni", "gentoo", "magellanic"},
+			},
+		},
+		{
+			[]string{"macaroni", "gentoo", "magellanic"},
+			5,
+			[][]string{
+				[]string{"macaroni", "gentoo", "magellanic"},
+			},
+		},
+		{
+			[]string{"macaroni", "gentoo", "magellanic"},
+			-1,
+			nil,
+		},
+		{
+			[]string{"macaroni", "gentoo", "magellanic"},
+			0,
+			nil,
+		},
+		{
+			[]string{},
+			7,
+			[][]string{},
+		},
+	}
+
+	for idx, testCase := range testCases {
+		t.Run(fmt.Sprintf("%s_%d", t.Name(), idx), func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, BatchListIntoGroupsOf(testCase.stringList, testCase.n), testCase.result)
+		})
+	}
+}


### PR DESCRIPTION
This implements `BatchListIntoGroupsOf`, which will take a list of strings and batch them into groups of `batchSize`.