### PR TITLE
Add random string generation capabilities

### DIFF
--- a/random/random.go
+++ b/random/random.go
@@ -3,8 +3,8 @@ package random
 
 import (
 	"bytes"
-	"math/rand"
-	"time"
+	"crypto/rand"
+	"math/big"
 )
 
 // Character sets that you can use when passing into RandomString
@@ -17,18 +17,16 @@ var Base62Chars = Digits + UpperLetters + LowerLetters
 
 // RandomString generates a random string of length strLength, composing only of characters in allowedChars. Based on
 // code here: http://stackoverflow.com/a/9543797/483528
-func RandomString(strLength int, allowedChars string) string {
+func RandomString(strLength int, allowedChars string) (string, error) {
 	var out bytes.Buffer
 
-	generator := newRand()
 	for i := 0; i < strLength; i++ {
-		out.WriteByte(allowedChars[generator.Intn(len(allowedChars))])
+		id, err := rand.Int(rand.Reader, big.NewInt(int64(len(allowedChars))))
+		if err != nil {
+			return out.String(), err
+		}
+		out.WriteByte(allowedChars[id.Int64()])
 	}
 
-	return out.String()
-}
-
-// newRand creates a new random number generator, seeding it with the current system time.
-func newRand() *rand.Rand {
-	return rand.New(rand.NewSource(time.Now().UnixNano()))
+	return out.String(), nil
 }

--- a/random/random.go
+++ b/random/random.go
@@ -17,6 +17,20 @@ var Base62Chars = Digits + UpperLetters + LowerLetters
 
 // RandomString generates a random string of length strLength, composing only of characters in allowedChars. Based on
 // code here: http://stackoverflow.com/a/9543797/483528
+// For convenience, the random package exposes various character sets you can use for the allowedChars parameter. Here
+// are a few examples:
+//
+// // Only lower case chars + digits
+// random.RandomString(6, random.Digits + random.LowerLetters)
+//
+// // alphanumerics + special chars
+// random.RandomString(6, random.Base62Chars + random.SpecialChars)
+//
+// // Only alphanumerics (base62)
+// random.RandomString(6, random.Base62Chars)
+//
+// // Only abc
+// random.RandomString(6, "abc")
 func RandomString(strLength int, allowedChars string) (string, error) {
 	var out bytes.Buffer
 

--- a/random/random.go
+++ b/random/random.go
@@ -1,0 +1,34 @@
+// Package random provides utilities and functions for generating random data.
+package random
+
+import (
+	"bytes"
+	"math/rand"
+	"time"
+)
+
+// Character sets that you can use when passing into RandomString
+const Digits = "0123456789"
+const UpperLetters = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+const LowerLetters = "abcdefghijklmnopqrstuvwxyz"
+const SpecialChars = "<>[]{}()-_*%&/?\"'\\"
+
+var Base62Chars = Digits + UpperLetters + LowerLetters
+
+// RandomString generates a random string of length strLength, composing only of characters in allowedChars. Based on
+// code here: http://stackoverflow.com/a/9543797/483528
+func RandomString(strLength int, allowedChars string) string {
+	var out bytes.Buffer
+
+	generator := newRand()
+	for i := 0; i < strLength; i++ {
+		out.WriteByte(allowedChars[generator.Intn(len(allowedChars))])
+	}
+
+	return out.String()
+}
+
+// newRand creates a new random number generator, seeding it with the current system time.
+func newRand() *rand.Rand {
+	return rand.New(rand.NewSource(time.Now().UnixNano()))
+}

--- a/random/random_test.go
+++ b/random/random_test.go
@@ -1,6 +1,7 @@
 package random
 
 import (
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -28,5 +29,18 @@ func TestRandomStringRespectsStrLen(t *testing.T) {
 		newStr, err := RandomString(i, Base62Chars)
 		require.NoError(t, err)
 		assert.Equal(t, len(newStr), i)
+	}
+}
+
+func TestRandomStringRespectsAllowedChars(t *testing.T) {
+	t.Parallel()
+
+	for i := 0; i < 100; i++ {
+		newStr, err := RandomString(10, Digits)
+		require.NoError(t, err)
+		// Since the new string should only be composed of digits, if RandomString respects allowed chars you should
+		// always be able to convert the string to an int
+		_, err = strconv.Atoi(newStr)
+		require.NoError(t, err)
 	}
 }

--- a/random/random_test.go
+++ b/random/random_test.go
@@ -13,7 +13,8 @@ func TestRandomStringIsMostlyRandom(t *testing.T) {
 	// Ensure that there is no overlap in 32 character random strings generated 100 times
 	seen := map[string]bool{}
 	for i := 0; i < 100; i++ {
-		newStr := RandomString(32, Base62Chars)
+		newStr, err := RandomString(32, Base62Chars)
+		require.NoError(t, err)
 		_, hasSeen := seen[newStr]
 		require.False(t, hasSeen)
 		seen[newStr] = true
@@ -24,7 +25,8 @@ func TestRandomStringRespectsStrLen(t *testing.T) {
 	t.Parallel()
 
 	for i := 0; i < 40; i++ {
-		newStr := RandomString(i, Base62Chars)
+		newStr, err := RandomString(i, Base62Chars)
+		require.NoError(t, err)
 		assert.Equal(t, len(newStr), i)
 	}
 }

--- a/random/random_test.go
+++ b/random/random_test.go
@@ -1,0 +1,30 @@
+package random
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRandomStringIsMostlyRandom(t *testing.T) {
+	t.Parallel()
+
+	// Ensure that there is no overlap in 32 character random strings generated 100 times
+	seen := map[string]bool{}
+	for i := 0; i < 100; i++ {
+		newStr := RandomString(32, Base62Chars)
+		_, hasSeen := seen[newStr]
+		require.False(t, hasSeen)
+		seen[newStr] = true
+	}
+}
+
+func TestRandomStringRespectsStrLen(t *testing.T) {
+	t.Parallel()
+
+	for i := 0; i < 40; i++ {
+		newStr := RandomString(i, Base62Chars)
+		assert.Equal(t, len(newStr), i)
+	}
+}


### PR DESCRIPTION
In the GCP bootstrap script I am currently developing, I have a need to generate a random string that I can use as a unique identifier for seeding the Project ID when creating a new project. I haven't seen us provide this as a library outside of `terratest`, so I ported a version of `random.UniqueId` here that is more generic, where you can control char sets and digits.

Note that this uses `crypto/rand` instead of `math/rand`, to allow for potential usage with password generation.