### PR TITLE
Improve ErrorWithExitCode

### DIFF
--- a/entrypoint/entrypoint.go
+++ b/entrypoint/entrypoint.go
@@ -39,23 +39,38 @@ func RunApp(app *cli.App) {
 // If there is an error, display it in the console and exit with a non-zero exit code. Otherwise, exit 0.
 // Note that if the GRUNTWORK_DEBUG environment variable is set, this will print out the stack trace.
 func checkForErrorsAndExit(err error) {
-	exitCode := defaultSuccessExitCode
-	isDebugMode := os.Getenv(debugEnvironmentVarName) != ""
+	logError(err)
+	exitCode := getExitCode(err)
+	os.Exit(exitCode)
+}
 
+// logError will output an error message to stderr. This will output the stack trace if we are in debug mode.
+func logError(err error) {
+	isDebugMode := os.Getenv(debugEnvironmentVarName) != ""
 	if err != nil {
+		errWithoutStackTrace := errors.Unwrap(err)
 		if isDebugMode {
 			logging.GetLogger("").WithError(err).Error(errors.PrintErrorWithStackTrace(err))
 		} else {
-			fmt.Fprintf(os.Stderr, "ERROR: %s\n", errors.Unwrap(err))
+			fmt.Fprintf(os.Stderr, "ERROR: %s\n", errWithoutStackTrace)
 		}
+	}
+}
 
-		errorWithExitCode, isErrorWithExitCode := err.(errors.ErrorWithExitCode)
+// getExitCode will return an exit code to use for the CLI app. This will either be:
+// - defaultSuccessExitCode if there is no error.
+// - defaultErrorExitCode if there is a standard error.
+// - error exit code if there is an error that indicates an exit code.
+func getExitCode(err error) int {
+	exitCode := defaultSuccessExitCode
+	if err != nil {
+		errWithoutStackTrace := errors.Unwrap(err)
+		errorWithExitCode, isErrorWithExitCode := errWithoutStackTrace.(errors.ErrorWithExitCode)
 		if isErrorWithExitCode {
 			exitCode = errorWithExitCode.ExitCode
 		} else {
 			exitCode = defaultErrorExitCode
 		}
 	}
-
-	os.Exit(exitCode)
+	return exitCode
 }

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -2,6 +2,7 @@ package errors
 
 import (
 	"fmt"
+
 	goerrors "github.com/go-errors/errors"
 	"github.com/urfave/cli"
 )
@@ -13,7 +14,7 @@ type ErrorWithExitCode struct {
 }
 
 func (err ErrorWithExitCode) Error() string {
-	return fmt.Sprintf("ErrorWithExitCode{ Err = %v, ExitCode = %d }", err.Err, err.ExitCode)
+	return err.Err.Error()
 }
 
 // Wrap the given error in an Error type that contains the stack trace. If the given error already has a stack trace,


### PR DESCRIPTION
I noticed that the user experience for returning `ErrorWithExitCode` isn't quite great, so I made a few improvements here:

- Support using both `WithStackTrace` and `ErrorWithExitCode`, so that you can get both a stack trace and exit with exit code.
- Output the underlying error message instead of `ErrorWithExitCode{ Err = Deployment failed, ExitCode = 1 }`
- Refactor `checkForErrorsAndExit` so we can test the exit code functionality without the test exiting due to the call to `os.Exit`.