### PR TITLE
Introduce a log text formatter that prefixes the binary name to the log entry

### DIFF
--- a/logging/formatter.go
+++ b/logging/formatter.go
@@ -1,0 +1,28 @@
+package logging
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/sirupsen/logrus"
+)
+
+// TextFormatterWithBinName is a logrus formatter that prefixes the binary name to the log output.
+type TextFormatterWithBinName struct {
+	Name          string
+	TextFormatter logrus.TextFormatter
+}
+
+func (formatter *TextFormatterWithBinName) Format(entry *logrus.Entry) ([]byte, error) {
+	logTxt, err := formatter.TextFormatter.Format(entry)
+	if err != nil {
+		return logTxt, err
+	}
+
+	outBuf := &bytes.Buffer{}
+	fmt.Fprintf(outBuf, "[%s] ", formatter.Name)
+	if _, err := outBuf.Write(logTxt); err != nil {
+		return logTxt, err
+	}
+	return outBuf.Bytes(), nil
+}

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -1,11 +1,10 @@
 package logging
 
 import (
-	"github.com/sirupsen/logrus"
 	"sync"
-)
 
-const loggerNameField = "name"
+	"github.com/sirupsen/logrus"
+)
 
 var globalLogLevel = logrus.InfoLevel
 var globalLogLevelLock = sync.Mutex{}
@@ -16,15 +15,14 @@ func GetLogger(name string) *logrus.Logger {
 
 	logger.Level = globalLogLevel
 
-	logger.Formatter = &logrus.TextFormatter{
-		FullTimestamp: true,
+	logger.Formatter = &TextFormatterWithBinName{
+		Name: name,
+		TextFormatter: logrus.TextFormatter{
+			FullTimestamp: true,
+		},
 	}
 
-	if name != "" {
-		return logger.WithField(loggerNameField, name).Logger
-	} else {
-		return logger.WithFields(make(logrus.Fields)).Logger
-	}
+	return logger
 }
 
 // Set the log level. Note: this ONLY affects loggers created using the GetLogger function AFTER this function has been


### PR DESCRIPTION
Gives you logs that look like below:

```
[infrastructure-deployer] INFO[2020-08-19T11:23:08-05:00]   ami-builder
[infrastructure-deployer] INFO[2020-08-19T11:23:08-05:00]       build-packer-artifact
[infrastructure-deployer] INFO[2020-08-19T11:23:08-05:00]   docker-image-builder
[infrastructure-deployer] INFO[2020-08-19T11:23:08-05:00]       build-docker-image
[infrastructure-deployer] INFO[2020-08-19T11:23:08-05:00]   terraform-applier
[infrastructure-deployer] INFO[2020-08-19T11:23:08-05:00]       infrastructure-deploy-script
[infrastructure-deployer] INFO[2020-08-19T11:23:08-05:00]       terraform-update-variable
[infrastructure-deployer] INFO[2020-08-19T11:23:08-05:00]   terraform-planner
[infrastructure-deployer] INFO[2020-08-19T11:23:08-05:00]       infrastructure-deploy-script
```
