### PR TITLE
Add version package

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 [![Maintained by Gruntwork.io](https://img.shields.io/badge/maintained%20by-gruntwork.io-%235849a6.svg)](https://gruntwork.io/?ref=repo_gruntwork-cli)
 [![GoDoc](https://godoc.org/github.com/gruntwork-io/gruntwork-cli?status.svg)](https://godoc.org/github.com/gruntwork-io/gruntwork-cli)
 
@@ -41,28 +40,22 @@ package main
 import (
         "github.com/urfave/cli"
         "github.com/gruntwork-io/gruntwork-cli/entrypoint"
-)	
-
-// This variable is set at build time using -ldflags parameters. For example, we typically set this flag in circle.yml
-// to the latest Git tag when building our Go apps:
-//
-// build-go-binaries --app-name my-app --dest-path bin --ld-flags "-X main.VERSION=$CIRCLE_TAG"
-//
-// For more info, see: http://stackoverflow.com/a/11355611/483528
-var VERSION string
+        "github.com/gruntwork-io/gruntwork-cli/version"
+)
 
 func main() {
       // Create a new CLI app. This will return a urfave/cli App with some
       // common initialization.
       app := entrypoint.NewApp()
-    
+
       app.Name = "my-app"
       app.Author = "Gruntwork <www.gruntwork.io>"
-      
-      // Set the version number from your app from the VERSION variable that is passed in at build time
-      app.Version = VERSION
-      
-      app.Action = func(cliContext *cli.Context) error { 
+
+      // Set the version number from your app from the VERSION variable that is passed in at build time in `version` package
+      // for more understanding see github.com/gruntwork-io/gruntwork-cli/version
+      app.Version = version.Version()
+
+      app.Action = func(cliContext *cli.Context) error {
         // ( fill in your app details)
         return nil
       }
@@ -89,7 +82,7 @@ change in the future, so the rest of the code should not depend on `go-errors` d
 Here is how the `errors` package should be used:
 
 1. Any time you want to create your own error, create a custom type for it, and when instantiating that type, wrap it
-   with a call to `errors.WithStackTrace`. That way, any time you call a method defined in our own code, you know the 
+   with a call to `errors.WithStackTrace`. That way, any time you call a method defined in our own code, you know the
    error it returns already has a stacktrace and you don't have to wrap it yourself.
 1. Any time you get back an error object from a function built into Go or a 3rd party library, immediately wrap it with
    `errors.WithStackTrace`. This gives us a stacktrace as close to the source as possible.
@@ -100,18 +93,18 @@ Note that `entrypoint.RunApp` takes care of showing stack traces and handling ex
 
 ### files
 
-This package has a number of helpers for working with files and file paths, including one-liners for checking if a 
+This package has a number of helpers for working with files and file paths, including one-liners for checking if a
 given path is a file or a directory, reading a file as a string, and building relative and canonical file paths.
 
 ### logging
 
-This package contains utilities for logging from our CLI apps. Instead of using Go's built-in logging library, we are 
-using [logrus](github.com/sirupsen/logrus), as it supports log levels (INFO, WARN, DEBUG, etc), structured logging 
-(making key=value pairs easier to parse), log formatting (including text and JSON), hooks to connect logging to a 
+This package contains utilities for logging from our CLI apps. Instead of using Go's built-in logging library, we are
+using [logrus](github.com/sirupsen/logrus), as it supports log levels (INFO, WARN, DEBUG, etc), structured logging
+(making key=value pairs easier to parse), log formatting (including text and JSON), hooks to connect logging to a
 variety of external systems (e.g. syslog, airbrake, papertrail), and even hooks for automated testing.
- 
+
 To get a Logger, call the `logging.GetLogger` method:
- 
+
 ```go
 logger := logging.GetLogger("my-app")
 logger.Info("Something happened!")
@@ -142,4 +135,3 @@ go test -v ./...
 ## License
 
 This code is released under the MIT License. See [LICENSE.txt](LICENSE.txt).
-

--- a/entrypoint/help_utils.go
+++ b/entrypoint/help_utils.go
@@ -68,7 +68,7 @@ func WrappedHelpPrinter(out io.Writer, templateString string, data interface{}) 
 // Similar functionality to regexp.Split, but returns the delimited strings
 // with the trailing delimiter appended to it.
 // Example:
-//    re := regexp.MustCompile("\\s+")
+//    re := regexp.MustCompile(`\s+`)
 //    text := "one two three"
 //    out := RegexpSplitAfter(re, text)
 //    out == ["one ", "two ", "three"]
@@ -100,7 +100,7 @@ func RegexpSplitAfter(re *regexp.Regexp, str string) []string {
 //        \tlogging into Gruntwork Houston
 func IndentAwareWrapText(text string, lineWidth int, indent string) string {
 	wrapped := ""
-	re := regexp.MustCompile("\\s+")
+	re := regexp.MustCompile(`\s+`)
 	words := RegexpSplitAfter(re, text)
 	if len(words) == 0 {
 		return wrapped
@@ -147,11 +147,11 @@ func HelpTableAwareDetermineIndent(text string, tableDelimiterRe string) string 
 	tableRe := regexp.MustCompile(tableDelimiterRe)
 	loc := tableRe.FindStringIndex(text)
 	if loc != nil {
-		return regexp.MustCompile("[^\\s]").ReplaceAllString(text[:loc[1]], " ")
+		return regexp.MustCompile(`[^\s]`).ReplaceAllString(text[:loc[1]], " ")
 	}
 
 	// ... otherwise, indent one
-	re := regexp.MustCompile("^\\s*")
+	re := regexp.MustCompile(`^\s*`)
 	loc = re.FindStringIndex(text)
 	if loc == nil {
 		return ""

--- a/entrypoint/help_utils_test.go
+++ b/entrypoint/help_utils_test.go
@@ -3,8 +3,9 @@ package entrypoint
 import (
 	"regexp"
 
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 var splitAfterTests = []struct {
@@ -21,7 +22,7 @@ var splitAfterTests = []struct {
 func TestRegexpSplitAfterDelimiter(t *testing.T) {
 	for _, tt := range splitAfterTests {
 		t.Run(tt.in, func(t *testing.T) {
-			re := regexp.MustCompile("\\s+")
+			re := regexp.MustCompile(`\s+`)
 			assert.Equal(t, RegexpSplitAfter(re, tt.in), tt.out)
 		})
 	}

--- a/version/version.go
+++ b/version/version.go
@@ -1,0 +1,18 @@
+package version
+
+// This variable is set at build time using -ldflags parameters. For example, we typically set this flag in circle.yml
+// to the latest Git tag when building our Go apps:
+//
+// build-go-binaries --app-name my-app --dest-path bin --ld-flags "-X github.com/gruntwork-io/gruntwork-cli/version.VERSION=$CIRCLE_TAG"
+// go build -o my-app -ldflags "-X github.com/gruntwork-io/gruntwork-cli/version.VERSION=v1.0.0"
+//
+// For more info, see: http://stackoverflow.com/a/11355611/483528
+
+var (
+	VERSION = "latest"
+)
+
+// Version composes a version of the package
+func Version() string {
+	return VERSION
+}


### PR DESCRIPTION
I would want to add only one package `version`. To be honest I don't like keep VERSION in main.go.
Reasons:
1. VERSION - uppercase 
2. This forces to always add an excess arg `cli.NewApp(VERSION)`

It's easy to make DevOps compatible with both implementations. Just try to rewrite in both places:
`-ldflags "-X main.VERSION=v1.0.0 -X github.com/gruntwork-io/gruntwork-cli/version.VERSION=v1.0.0"`