### PR TITLE
Add GetStdout flavors

### DIFF
--- a/shell/cmd_test.go
+++ b/shell/cmd_test.go
@@ -3,6 +3,7 @@ package shell
 import (
 	"bytes"
 	"fmt"
+	"path/filepath"
 	"testing"
 
 	"github.com/gruntwork-io/gruntwork-cli/logging"
@@ -27,6 +28,22 @@ func TestRunShellCommandAndGetOutput(t *testing.T) {
 	out, err := RunShellCommandAndGetOutput(NewShellOptions(), "echo", "hi")
 	assert.NoError(t, err)
 	assert.Equal(t, "hi\n", out)
+}
+
+func TestRunShellCommandAndGetStdoutReturnsStdout(t *testing.T) {
+	t.Parallel()
+
+	out, err := RunShellCommandAndGetStdout(NewShellOptions(), "echo", "hi")
+	assert.NoError(t, err)
+	assert.Equal(t, "hi\n", out)
+}
+
+func TestRunShellCommandAndGetStdoutDoesNotReturnStderr(t *testing.T) {
+	t.Parallel()
+
+	out, err := RunShellCommandAndGetStdout(NewShellOptions(), filepath.Join("test-fixture", "echo_hi_stderr.sh"))
+	assert.NoError(t, err)
+	assert.Equal(t, "", out)
 }
 
 func TestRunShellCommandWithEnv(t *testing.T) {

--- a/shell/test-fixture/echo_hi_stderr.sh
+++ b/shell/test-fixture/echo_hi_stderr.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+>&2 echo "hi"


### PR DESCRIPTION
This adds `RunCommandAndGetStdout` flavors of `RunCommand`. I could probably do a better job with refactoring to make things DRY, but I don't have enough of an appetite right now to clean things up as this is blocking the architecture catalog automation work.